### PR TITLE
docs: Archive GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: `actions-document-publish` is no longer maintained, please consider using [`BaileyJM02/markdown-to-pdf`][markdown-to-pdf] directly instead, as this action is a very simple wrapper around `markdown-to-pdf`.
+
 # Document Publish
 
 A GitHub Action for publishing a set of one or more Markdown files as a single


### PR DESCRIPTION
I don't intend to make any changes to this GitHub Action in the future, so I am marking it as archived. The action will continue to work, so there is no immediate impact for users, however, future users should consider using `markdown-to-pdf` directly instead as it is straightforward to use and supports many more use-cases.